### PR TITLE
Fix raw component missing properties and check for input before sending message

### DIFF
--- a/src/raw.riot
+++ b/src/raw.riot
@@ -9,13 +9,13 @@
       // Replaces all ampersand, less-than, greater-than, and
       // quotes symbols with their corresponding HTML reference.
       setInnerHTMLSanitized() {
-        if(this.props.htmlWithLinks) {
+        if(typeof this.props.htmlWithLinks === "string") {
           // Regex for setting up anchors points to symbols from RFC 3986 (URI specification)
           this.root.innerHTML = this.props.htmlWithLinks.replaceAll('&', "&amp;").replaceAll('<', "&lt;").replaceAll('>', "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&apos;").replaceAll(/((http|https):\/\/[a-z0-9\:\/\?\#\[\]\@\!\$\&\'\(\)\*\+\,\;\=\-\.\_\~\%]+)/ig, "<a href='$1' style='color: blue' target='_blank' rel='noopener noreferrer'>$1</a>")
-        } else if(this.props.html) {
+        } else if(typeof this.props.html === "string") {
           this.root.innerHTML = this.props.html.replaceAll('&', "&amp;").replaceAll('<', "&lt;").replaceAll('>', "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&apos;")
         } else {
-          console.error("Raw component is missing properties. Expected either html or htmlWithLinks. Got: ", this.props)
+          console.error("Raw component is missing properties. Expected either html or htmlWithLinks as typeof string. Got: ", this.props)
         }
       },
       onMounted() {

--- a/src/webchat-channel.riot
+++ b/src/webchat-channel.riot
@@ -22,7 +22,7 @@
                 </div>
 
                 <p if={!item.data.hasBlob} class="text-black leading-normal">
-                    <raw htmlWithLinks={ item.data.text }/>
+                    <raw htmlWithLinks={ item.data.text ? item.data.text : "" }/>
                 </p>
 
                 <template if={item.data.hasBlob}>
@@ -195,12 +195,14 @@
 
                 const messageText = messageElement.value;
 
-                const fileElement = this.$(`#chatAreaInputFile_${this.props.item.id1.toString("hex")}`);
-                const file = fileElement.files[0];
+                if (messageText) {
+                    const fileElement = this.$(`#chatAreaInputFile_${this.props.item.id1.toString("hex")}`);
+                    const file = fileElement.files[0];
 
-                this.clearMessageAndFileInputs();
+                    this.clearMessageAndFileInputs();
 
-                this.state.controller.submitMessage(messageText, file);
+                    this.state.controller.submitMessage(messageText, file);
+                }
             },
 
             clearMessageAndFileInputs(event) {


### PR DESCRIPTION
* Improve setInnerHTMLSanitized to expect string properties, exclusively. This
fixes the case of empty or undefined values not being identified as valid settings 
("Raw component is missing properties" error).
Resolves #18

* Handle possible case of "undefined" (no message text) reaching the client. 
Transform undefined as empty string "", consequently rendedring raw as an
empty element <raw></raw>

* Check message input value is set before calling submitMessage. This fix
prevents sending messages with value set to "undefined". Empty values
result in NOOP